### PR TITLE
Add support for Windows and macOS platforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Minimalist's Home Gateway",
   "main": "main.js",
   "dependencies": {
-    "arped": "^0.2.0",
+    "arp-a": "^0.5.1",
     "body-parser": "^1.17.2",
     "echonet-lite": "^0.0.17",
     "express": "^4.15.2",
@@ -12,6 +12,7 @@
     "mime": "^1.3.4",
     "opts": "^1.2.6",
     "ping": "^0.2.2",
+    "underscore": "^1.8.3",
     "websocket": "^1.0.24"
   },
   "devDependencies": {},


### PR DESCRIPTION
Add support for Windows and macOS platforms.
Replace arp module to 'arp-a' from 'arp'.
